### PR TITLE
Upgrade Python and NumPy

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Install dependencies
       run: pip install tox
     - name: Test with tox

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# python:3.7-bullseye
+# python:3.9-bullseye
 FROM python@sha256:efb5ab0fef765227c65ddc52e524b8e2766f65c6c119b908744ff5c840dfd2d3
 
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # python:3.7-bullseye
-FROM python@sha256:7d5ba6ac052be01bc68beefcd62de0b7fb8084f9b1e56035c5edce0b4cde946e
+FROM python@sha256:efb5ab0fef765227c65ddc52e524b8e2766f65c6c119b908744ff5c840dfd2d3
 
 WORKDIR /usr/src/app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py37']
+target-version = ['py39']
 # Keep exclude in sync with flake8 config in tox.ini
 exclude = '''
 /(

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ markupsafe==2.0.1
     # via mako
 numba==0.53.1
     # via fastparquet
-numpy==1.21.0
+numpy==1.22.4
     # via
     #   fastparquet
     #   numba

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,flake8,black
+envlist = py39,flake8,black
 
 [testenv]
 deps=


### PR DESCRIPTION
Upgrade Python to 3.9 since NumPy 1.21 doesn't support Python 3.7.

Upgrade NumPy to 1.22 since Python 3.9 doesn't support NumPy 1.21.